### PR TITLE
Migrate from Stack to Nix Flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,9 @@ dist
 cabal.sandbox.config
 .stack-work
 stack.yaml.lock
-dist-newstyle 
+dist-newstyle
+
+# Nix
+result
+result-*
+.direnv

--- a/NIX_MIGRATION.md
+++ b/NIX_MIGRATION.md
@@ -1,0 +1,176 @@
+# Migration from Stack to Nix Flake
+
+This document describes the migration from Stack to Nix Flake for the Gothic project.
+
+## What's New
+
+The project now includes a `flake.nix` file that provides:
+
+1. **Package builds** using Cabal via Nix
+2. **Development shells** with all necessary tools (GHC, cabal-install, HLS, ghcid)
+3. **Multiple GHC version support** (GHC 8.10, 9.0, 9.2, 9.4, 9.6)
+4. **Reproducible builds** across different machines
+
+## Prerequisites
+
+You need Nix with flake support enabled. If you don't have it:
+
+```bash
+# Install Nix
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
+# Or enable flakes in your existing Nix installation by adding to ~/.config/nix/nix.conf:
+experimental-features = nix-command flakes
+```
+
+## First-Time Setup
+
+After cloning the repository, initialize the flake:
+
+```bash
+nix flake update
+```
+
+This will generate a `flake.lock` file that pins all dependencies.
+
+## Building the Project
+
+### Using Nix Flake
+
+Build the default package (GHC 9.2.8):
+```bash
+nix build
+```
+
+Build with a specific GHC version:
+```bash
+nix build .#ghc-9-6    # GHC 9.6.6
+nix build .#ghc-9-4    # GHC 9.4.8
+nix build .#ghc-9-0    # GHC 9.0.2
+nix build .#ghc-8-10   # GHC 8.10.7
+```
+
+### Development Shell
+
+Enter the development environment (default GHC 9.2.8):
+```bash
+nix develop
+```
+
+Enter a development shell with a specific GHC version:
+```bash
+nix develop .#ghc-9-6
+nix develop .#ghc-9-4
+```
+
+Inside the development shell, you can use familiar Cabal commands:
+```bash
+cabal build
+cabal test
+cabal repl
+ghcid  # Auto-reload on file changes
+```
+
+### Using direnv (Recommended)
+
+For automatic environment activation, install direnv and create a `.envrc` file:
+
+```bash
+echo "use flake" > .envrc
+direnv allow
+```
+
+Now the development environment will activate automatically when you enter the directory.
+
+## Running the Project
+
+### Direct execution
+```bash
+nix run
+```
+
+### In development shell
+```bash
+nix develop
+cabal run
+```
+
+## CI/CD Integration
+
+The flake can be used in CI/CD pipelines:
+
+```yaml
+# Example GitHub Actions workflow
+- name: Build with Nix
+  run: nix build
+
+- name: Test with Nix
+  run: nix develop --command cabal test
+```
+
+## Differences from Stack
+
+| Stack | Nix Flake |
+|-------|-----------|
+| `stack build` | `nix build` or `cabal build` (in dev shell) |
+| `stack test` | `nix develop -c cabal test` |
+| `stack repl` | `nix develop -c cabal repl` |
+| `stack exec` | `nix run` |
+| `stack.yaml` | `flake.nix` + `flake.lock` |
+
+## Keeping Stack (Optional)
+
+The `stack.yaml` file is still present and functional. You can use either:
+- **Nix Flake** for reproducible builds and nixos integration
+- **Stack** if you prefer or need stack-specific features
+
+Both tools use the same `gothic.cabal` file as the source of truth.
+
+## Updating Dependencies
+
+### Update flake inputs
+```bash
+nix flake update
+```
+
+### Update Haskell dependencies
+Modify `gothic.cabal` and rebuild:
+```bash
+nix build --recreate-lock-file
+```
+
+## Troubleshooting
+
+### Build fails with "command not found"
+Make sure you're in a nix develop shell or using `nix develop -c <command>`
+
+### Flake is outdated
+```bash
+nix flake update
+nix build
+```
+
+### Cache issues
+```bash
+nix build --rebuild
+```
+
+### Clean build
+```bash
+nix clean
+nix build
+```
+
+## Benefits of Nix Flake
+
+1. **Reproducibility**: Exact dependency versions locked in `flake.lock`
+2. **Multi-version testing**: Easy to test against multiple GHC versions
+3. **No system pollution**: Dependencies are isolated per-project
+4. **Fast CI**: Nix binary cache speeds up CI builds significantly
+5. **NixOS integration**: Native integration with NixOS systems
+
+## Resources
+
+- [Nix Flakes Documentation](https://nixos.wiki/wiki/Flakes)
+- [Haskell on Nix](https://nixos.wiki/wiki/Haskell)
+- [callCabal2nix](https://nixos.org/manual/nixpkgs/stable/#haskell-cabal2nix)

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,3 +6,25 @@ Art. "Bank vault", Wikipedia.
 
 This library implements the [HashiCorp Vault KVv2 Engine API](https://www.vaultproject.io/api/secret/kv/kv-v2.html).
 
+## Building
+
+### With Nix Flake (Recommended)
+
+```bash
+# Build the project
+nix build
+
+# Enter development shell
+nix develop
+
+# Or use direnv for automatic environment activation
+echo "use flake" > .envrc && direnv allow
+```
+
+See [NIX_MIGRATION.md](NIX_MIGRATION.md) for detailed Nix Flake usage.
+
+### With Stack
+
+```bash
+stack build
+```

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,77 @@
+{
+  description = "Gothic - A Haskell Vault KVv2 secret engine client";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        haskellPackages = pkgs.haskell.packages.ghc928;
+
+        gothic = haskellPackages.callCabal2nix "gothic" ./. { };
+
+      in
+      {
+        packages = {
+          default = gothic;
+          gothic = gothic;
+        };
+
+        devShells.default = haskellPackages.shellFor {
+          packages = p: [ gothic ];
+
+          buildInputs = with haskellPackages; [
+            cabal-install
+            haskell-language-server
+            ghcid
+          ];
+
+          withHoogle = true;
+
+          shellHook = ''
+            echo "Gothic development environment"
+            echo "GHC version: ${haskellPackages.ghc.version}"
+            echo ""
+            echo "Available commands:"
+            echo "  cabal build    - Build the project"
+            echo "  cabal test     - Run tests"
+            echo "  cabal repl     - Start GHCi"
+            echo "  ghcid          - Auto-reload on changes"
+          '';
+        };
+
+        # Support for multiple GHC versions
+        packages.ghc-8-10 = pkgs.haskell.packages.ghc8107.callCabal2nix "gothic" ./. { };
+        packages.ghc-9-0  = pkgs.haskell.packages.ghc90.callCabal2nix "gothic" ./. { };
+        packages.ghc-9-2  = pkgs.haskell.packages.ghc928.callCabal2nix "gothic" ./. { };
+        packages.ghc-9-4  = pkgs.haskell.packages.ghc948.callCabal2nix "gothic" ./. { };
+        packages.ghc-9-6  = pkgs.haskell.packages.ghc966.callCabal2nix "gothic" ./. { };
+
+        # Development shells for different GHC versions
+        devShells.ghc-8-10 = pkgs.haskell.packages.ghc8107.shellFor {
+          packages = p: [ (pkgs.haskell.packages.ghc8107.callCabal2nix "gothic" ./. { }) ];
+          buildInputs = with pkgs.haskell.packages.ghc8107; [ cabal-install ];
+        };
+
+        devShells.ghc-9-0 = pkgs.haskell.packages.ghc90.shellFor {
+          packages = p: [ (pkgs.haskell.packages.ghc90.callCabal2nix "gothic" ./. { }) ];
+          buildInputs = with pkgs.haskell.packages.ghc90; [ cabal-install ];
+        };
+
+        devShells.ghc-9-4 = pkgs.haskell.packages.ghc948.shellFor {
+          packages = p: [ (pkgs.haskell.packages.ghc948.callCabal2nix "gothic" ./. { }) ];
+          buildInputs = with pkgs.haskell.packages.ghc948; [ cabal-install ];
+        };
+
+        devShells.ghc-9-6 = pkgs.haskell.packages.ghc966.shellFor {
+          packages = p: [ (pkgs.haskell.packages.ghc966.callCabal2nix "gothic" ./. { }) ];
+          buildInputs = with pkgs.haskell.packages.ghc966; [ cabal-install ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
Add comprehensive Nix Flake configuration for reproducible builds and development environments.

Changes:
- Add flake.nix with support for multiple GHC versions (8.10, 9.0, 9.2, 9.4, 9.6)
- Add NIX_MIGRATION.md documenting the migration and usage
- Update ReadMe.md with Nix build instructions
- Update .gitignore with Nix-related entries (result, .direnv)

The project now supports both Stack and Nix workflows. Nix provides:
- Reproducible builds with locked dependencies
- Development shells with GHC, cabal-install, HLS, and ghcid
- Easy multi-version GHC testing
- Better CI/CD integration